### PR TITLE
docs(README/roadmap): add tentative roadmap of the project

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-  "cSpell.words": ["choosenim", "katima", "kyūjitai", "shinjitai"]
+  "cSpell.words": [
+    "choosenim",
+    "Fullwidth",
+    "Halfwidth",
+    "Joyo",
+    "katima",
+    "kyūjitai",
+    "Romaji",
+    "shinjitai"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# katima
+
+## Roadmap
+
+### Status
+
+| Icon  | Description     |
+| :---: | :-------------- |
+|   ❌   | Not implemented |
+|   🚧   | In progress     |
+|   ✅   | Implemented     |
+
+### Check
+
+| Status | Function Name       | Description |
+| :----: | :------------------ | :---------- |
+|   ❌    | isHiragana          |             |
+|   ❌    | isFullwidthKatakana |             |
+|   ❌    | isHalfwidthKatakana |             |
+|   ❌    | isCjkIdeograph      |             |
+|   ❌    | isJoyoKanji         |             |
+|   ❌    | isKyujitai          |             |
+|   ❌    | isShinjitai         |             |
+|   ❌    | isFullwidth         |             |
+|   ❌    | isHalfwidth         |             |
+
+### Conversion
+
+| Status | Function Name        | Description |
+| :----: | :------------------- | :---------- |
+|   ❌    | toHiragana           |             |
+|   ❌    | toHiraganaFromRomaji |             |
+|   ❌    | toFullwidthKatakana  |             |
+|   ❌    | toHalfwidthKatakana  |             |
+|   ❌    | toRomaji             |             |
+|   ❌    | toKyujitai           |             |
+|   ❌    | toShinjitai          |             |
+|   ❌    | toFullwidth          |             |
+|   ❌    | toHalfwidth          |             |
+
+### Editing
+
+| Status | Function Name             | Description |
+| :----: | :------------------------ | :---------- |
+|   ❌    | addVoicedSoundMark        |             |
+|   ❌    | addSemiVoicedSoundMark    |             |
+|   ❌    | removeVoicedSoundMark     |             |
+|   ❌    | removeSemiVoicedSoundMark |             |
+|   ❌    | extractIterationMarks     |             |
+|   ❌    | extractDigraph            |             |
+
+### Information
+
+| Status | Function Name | Description |
+| :----: | :------------ | :---------- |
+|   ❌    | codePoint     |             |


### PR DESCRIPTION
This pull request introduces updates to the project configuration and documentation, focusing on improving spell-checking settings and providing a detailed roadmap for the `katima` library. The most important changes include expanding the cSpell dictionary and adding a structured roadmap to the `README.md` file.

### Configuration Updates:
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L2-R11): Expanded the `cSpell.words` list to include additional terms relevant to the `katima` library, such as "Fullwidth," "Halfwidth," "Joyo," and "Romaji," to reduce false positives during spell-checking.

### Documentation Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R56): Added a detailed roadmap for the `katima` library, outlining the current implementation status of various functions grouped into categories like "Check," "Conversion," "Editing," and "Information." Each function is marked with its implementation status (e.g., ❌ for not implemented).